### PR TITLE
added optional sourcemap preprocessor

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,13 @@
-const karmaConstants = require('karma').constants;
-const merge = require('webpack-merge');
+const karmaConstants = require( 'karma' ).constants;
+const merge = require( 'webpack-merge' );
+
+let sourcemapPluginExists = false;
+try {
+  require( 'karma-sourcemap-loader' );
+  sourcemapPluginExists = true;
+} catch (ex) {
+
+}
 
 module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
   delete webpackConfig.entry;
@@ -7,10 +15,15 @@ module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
     devtool: 'inline-source-map'
   } );
 
+  const enabledPreprocessors = [ 'webpack' ];
+  if ( sourcemapPluginExists ) {
+    enabledPreprocessors.push( 'sourcemap' );
+  }
+
   const preprocessors = {};
 
   karmaOptions.files.map( fileNameOrPattern => {
-    preprocessors[ fileNameOrPattern ] = [ 'webpack' ];
+    preprocessors[ fileNameOrPattern ] = enabledPreprocessors;
   } );
 
   let karmaConfig = {


### PR DESCRIPTION
Hi, at the moment karmajs plugin adds only webpack preprocessor.
I thought, that it would be nice to have sourcemap preprocessor as well to show original file and line number.

Since `karma-sourcemap-loader` might be not installed, I add this preprocessor, only if this module exists

@tushararora would you mind having a look, please? :)