### PR TITLE
added possibility to override browsers via cli arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,11 +27,15 @@ module.exports = ( api, projectOptions ) => {
   api.registerCommand( 'test:unit', {
       description: 'Run unit tests with karma',
       usage: 'vue-cli-service test:unit [options] [...files]',
+      options: {
+        '--watch, -w': 'run in watch mode',
+        '--browsers, -b': ' A list of browsers to launch and capture'
+      }
     }, ( args ) => {
       const webpackConfig = api.resolveWebpackConfig();
 
-      process.env.VUE_CLI_BABEL_TARGET_NODE = true
-      process.env.VUE_CLI_BABEL_TRANSPILE_MODULES = true
+      process.env.VUE_CLI_BABEL_TARGET_NODE = true;
+      process.env.VUE_CLI_BABEL_TRANSPILE_MODULES = true;
 
       return new Promise( ( resolve, reject ) => {
         let KarmaServer = require( 'karma' ).Server;
@@ -41,7 +45,8 @@ module.exports = ( api, projectOptions ) => {
           generateKarmaConfig( {
             webpackConfig,
             karmaOptions,
-            watch: args.watch || args.w
+            watch: args.watch || args.w,
+            browsers: args.browsers || args.b
           } ), ( exitCode ) => {
             console.log( `Karma exited with exitCode ${exitCode}` );
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
-const karmaConstants = require('karma').constants;
-const merge = require('webpack-merge');
+const karmaConstants = require( 'karma' ).constants;
+const merge = require( 'webpack-merge' );
 
-module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
+module.exports = ( { webpackConfig, karmaOptions, watch, browsers } ) => {
   delete webpackConfig.entry;
   webpackConfig = merge( webpackConfig, {
     devtool: 'inline-source-map'
@@ -12,6 +12,14 @@ module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
   karmaOptions.files.map( fileNameOrPattern => {
     preprocessors[ fileNameOrPattern ] = [ 'webpack' ];
   } );
+
+  if ( browsers ) {
+    if ( (typeof browsers === 'string') || (browsers instanceof String) ) {
+      browsers = browsers.split( ',' );
+    }
+  } else {
+    browsers = karmaOptions.browsers;
+  }
 
   let karmaConfig = {
     files: karmaOptions.files,
@@ -24,7 +32,7 @@ module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
 
     singleRun: !watch,
 
-    browsers: karmaOptions.browsers,
+    browsers: browsers,
 
     frameworks: karmaOptions.frameworks,
 


### PR DESCRIPTION
It would be nice to have a possibility to override browsers with CLI argument.
Use case: 
Locally I want to run 
`vue-cli-service test:unit` with Chrome and Firefox by default

But on CI (e.g. travis) it's not possible, so I'd like to have 
`"test:unit-ci": "vue-cli-service test:unit -b ChromeHeadless"`

This PR allows overriding browsers config via CLI arg