### PR TITLE
Standalone karma conf

### DIFF
--- a/default-karma-config.js
+++ b/default-karma-config.js
@@ -1,8 +1,8 @@
-    
+const karmaConstants = require( 'karma' ).constants;
+
 /**
  * Default config for karma
  */
-  
 module.exports = {
   files: [
     'tests/unit/**/*.spec.js'
@@ -13,4 +13,10 @@ module.exports = {
   browsers: [ 'Chrome', 'Firefox' ],
 
   frameworks: [ 'mocha', 'chai' ],
+
+  logLevel: karmaConstants.LOG_ERROR,
+
+  webpackMiddleware: {
+    stats: 'minimal'
+  }
 };

--- a/index.js
+++ b/index.js
@@ -27,11 +27,15 @@ module.exports = ( api, projectOptions ) => {
   api.registerCommand( 'test:unit', {
       description: 'Run unit tests with karma',
       usage: 'vue-cli-service test:unit [options] [...files]',
+      options: {
+        '--watch, -w': 'run in watch mode',
+        '--browsers, -b': ' A list of browsers to launch and capture'
+      }
     }, ( args ) => {
       const webpackConfig = api.resolveWebpackConfig();
 
-      process.env.VUE_CLI_BABEL_TARGET_NODE = true
-      process.env.VUE_CLI_BABEL_TRANSPILE_MODULES = true
+      process.env.VUE_CLI_BABEL_TARGET_NODE = true;
+      process.env.VUE_CLI_BABEL_TRANSPILE_MODULES = true;
 
       return new Promise( ( resolve, reject ) => {
         let KarmaServer = require( 'karma' ).Server;
@@ -41,7 +45,8 @@ module.exports = ( api, projectOptions ) => {
           generateKarmaConfig( {
             webpackConfig,
             karmaOptions,
-            watch: args.watch || args.w
+            watch: args.watch || args.w,
+            browsers: args.browsers || args.b
           } ), ( exitCode ) => {
             console.log( `Karma exited with exitCode ${exitCode}` );
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,4 @@
-const karmaConstants = require('karma').constants;
-const merge = require('webpack-merge');
+const merge = require( 'webpack-merge' );
 
 module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
   delete webpackConfig.entry;
@@ -13,29 +12,18 @@ module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
     preprocessors[ fileNameOrPattern ] = [ 'webpack' ];
   } );
 
-  let karmaConfig = {
-    files: karmaOptions.files,
+  const karmaConfig = Object.assign( {}, karmaOptions );
 
-    reporters: karmaOptions.reporters,
+  Object.assign( karmaConfig, {
+      autoWatch: watch,
 
-    logLevel: karmaConstants.LOG_ERROR,
+      singleRun: !watch,
 
-    autoWatch: watch,
+      preprocessors,
 
-    singleRun: !watch,
-
-    browsers: karmaOptions.browsers,
-
-    frameworks: karmaOptions.frameworks,
-
-    preprocessors,
-
-    webpack: webpackConfig,
-
-    webpackMiddleware: {
-      stats: 'minimal'
+      webpack: webpackConfig
     }
-  };
+  );
 
   return karmaConfig;
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,13 @@
-const karmaConstants = require('karma').constants;
-const merge = require('webpack-merge');
+const karmaConstants = require( 'karma' ).constants;
+const merge = require( 'webpack-merge' );
+
+let sourcemapPluginExists = false;
+try {
+  require( 'karma-sourcemap-loader' );
+  sourcemapPluginExists = true;
+} catch (ex) {
+
+}
 
 module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
   delete webpackConfig.entry;
@@ -7,10 +15,15 @@ module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
     devtool: 'inline-source-map'
   } );
 
+  const enabledPreprocessors = [ 'webpack' ];
+  if ( sourcemapPluginExists ) {
+    enabledPreprocessors.push( 'sourcemap' );
+  }
+
   const preprocessors = {};
 
   karmaOptions.files.map( fileNameOrPattern => {
-    preprocessors[ fileNameOrPattern ] = [ 'webpack' ];
+    preprocessors[ fileNameOrPattern ] = enabledPreprocessors;
   } );
 
   let karmaConfig = {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
-const karmaConstants = require('karma').constants;
-const merge = require('webpack-merge');
+const karmaConstants = require( 'karma' ).constants;
+const merge = require( 'webpack-merge' );
 
-module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
+module.exports = ( { webpackConfig, karmaOptions, watch, browsers } ) => {
   delete webpackConfig.entry;
   webpackConfig = merge( webpackConfig, {
     devtool: 'inline-source-map'
@@ -12,6 +12,14 @@ module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
   karmaOptions.files.map( fileNameOrPattern => {
     preprocessors[ fileNameOrPattern ] = [ 'webpack' ];
   } );
+
+  if ( browsers ) {
+    if ( (typeof browsers === 'string') || (browsers instanceof String) ) {
+      browsers = browsers.split( ',' );
+    }
+  } else {
+    browsers = karmaOptions.browsers;
+  }
 
   let karmaConfig = {
     files: karmaOptions.files,
@@ -24,7 +32,7 @@ module.exports = ( { webpackConfig, karmaOptions, watch } ) => {
 
     singleRun: !watch,
 
-    browsers: karmaOptions.browsers,
+    browsers: browsers,
 
     frameworks: karmaOptions.frameworks,
 

--- a/standalone.karma.conf.js
+++ b/standalone.karma.conf.js
@@ -1,0 +1,17 @@
+const webpackConfig = require( '@vue/cli-service/webpack.config' );
+const karmaOptions = require( 'vue-cli-plugin-unit-karmajs/default-karma-config' );
+const path = require( 'path' );
+const karmaConfBuilder = require( 'vue-cli-plugin-unit-karmajs/karma.conf' );
+
+const customConfigPath = path.resolve( 'vue.config' );
+const currentProjectFolder = path.resolve( '.' );
+const customConfig = require( customConfigPath );
+if ( customConfig.pluginOptions && customConfig.pluginOptions.karma ) {
+    Object.assign( karmaOptions, customConfig.pluginOptions.karma );
+}
+
+module.exports = function ( config ) {
+    const newConfig = karmaConfBuilder( { webpackConfig, karmaOptions, watch: false } );
+    newConfig.basePath = currentProjectFolder;
+    config.set( newConfig );
+};


### PR DESCRIPTION
Added standalone karma configuration, which can be used for calling karma directly, outside of vue cli.
For example, this is needed, when you run karma tests from WebStorm