### PR TITLE
added standalone karma conf, to be used outside of vue cli

### DIFF
--- a/standalone.karma.conf.js
+++ b/standalone.karma.conf.js
@@ -1,3 +1,7 @@
+// If not set explicitly, set these envs to 'test', as vue-cli does by default for unit:test runners
+process.env.BABEL_ENV = process.env.BABEL_ENV || 'test'
+process.env.NODE_ENV = process.env.NODE_ENV || 'test'
+
 const webpackConfig = require( '@vue/cli-service/webpack.config' );
 const karmaOptions = require( 'vue-cli-plugin-unit-karmajs/default-karma-config' );
 const path = require( 'path' );

--- a/standalone.karma.conf.js
+++ b/standalone.karma.conf.js
@@ -1,0 +1,17 @@
+const webpackConfig = require( '@vue/cli-service/webpack.config' );
+const karmaOptions = require( 'vue-cli-plugin-unit-karmajs/default-karma-config' );
+const path = require( 'path' );
+const karmaConfBuilder = require( 'vue-cli-plugin-unit-karmajs/karma.conf' );
+
+const customConfigPath = path.resolve( 'vue.config' );
+const currentProjectFolder = path.resolve( '.' );
+const customConfig = require( customConfigPath );
+if ( customConfig.pluginOptions && customConfig.pluginOptions.karma ) {
+    Object.assign( karmaOptions, customConfig.pluginOptions.karma );
+}
+
+module.exports = function ( config ) {
+    const newConfig = karmaConfBuilder( { webpackConfig, karmaOptions, watch: false } );
+    newConfig.basePath = currentProjectFolder;
+    config.set( newConfig );
+};


### PR DESCRIPTION
Added standalone karma configuration, which can be used for calling karma directly, outside of vue cli.
For example, this is needed, when you run karma tests from WebStorm